### PR TITLE
Add libselinux-python to quickstart install_deps

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -12,7 +12,8 @@ install_deps () {
         /usr/bin/git \
         /usr/bin/virtualenv \
         gcc \
-        libyaml
+        libyaml \
+        libselinux-python
 }
 
 # This creates a Python virtual environment and installs


### PR DESCRIPTION
SELinux python bindings are needed for provision/remote user management.

I hit this on running tripleo-quickstart on a minimal installation of CentOS 7.
