### PR TITLE
fix UnicodeDecodeErrors on called scripts.

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Some scripts requires output to be in LANG=C and 
+#  only in ascii. Avoid localized command output
+#  eg. yum,... 
+export LANG=C
+
 DEFAULT_OPT_TAGS="untagged,provision,environment,undercloud-scripts,overcloud-scripts,undercloud-install,undercloud-post-install"
 
 : ${OPT_BOOTSTRAP:=0}


### PR DESCRIPTION
ssh sessions inherit LANG from client (in my case it_IT).

yum and other commands use LANG to localize command output.

If this output is not ascii, python could raise UnicodeDecodeErrors.

Setting LANG=C in the quickstart should prevent it.
